### PR TITLE
Switch to date-based tag

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/%%PARENT%%:current-22.04
+FROM cimg/%%PARENT%%:2022.09
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 


### PR DESCRIPTION
Now that cimg/base has defaulted to Ubuntu 22.04, we can use the traditional date-based tag.