### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
 
 workflows:
   main-wf:

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,8 +25,9 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
 	echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
 
 	# Setup Salt
-	sudo curl -fsSL -o /usr/share/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest/salt-archive-keyring.gpg && \
-	echo "deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/py3/ubuntu/20.04/amd64/latest focal main" | sudo tee /etc/apt/sources.list.d/salt.list && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+	sudo curl -fsSL -o /usr/share/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/py3/ubuntu/20.04/${ARCH}/latest/salt-archive-keyring.gpg && \
+	echo "deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=${ARCH}] https://repo.saltproject.io/py3/ubuntu/20.04/${ARCH}/latest focal main" | sudo tee /etc/apt/sources.list.d/salt.list && \
 
 	# Setup Kubectl
 	# You must use a kubectl version that is within one minor version difference of your cluster. For example, a v1.23 client can communicate with v1.22, v1.23, and v1.24 control planes.
@@ -38,7 +39,7 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
 
 	# Install Helm
 	HELM_VER=3.12.1 && \
-	curl -sSL "https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz" | sudo tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm && \
+	curl -sSL "https://get.helm.sh/helm-v${HELM_VER}-linux-${ARCH}.tar.gz" | sudo tar -xz --strip-components=1 -C /usr/local/bin linux-${ARCH}/helm && \
 	helm version && \
 
 	# Install tools from added Apt repos

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=deploy
 parent=base
 variants=(node)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Adds arm64 support via buildx multi arch builds

# Reasons

Enables arm64 support using the updating tooling in cimg-shared and cimg-orb and arch checks for the software included in this image

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-deploy/83/workflows/f79f2385-7c60-4ab9-8e99-6c3abf5ddde1/jobs/84

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
