### PR TITLE
feat: add check-feed job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,20 @@ version: 2.1
 
 orbs:
   cimg: circleci/cimg@0.3.3
+  gh: circleci/github-cli@2.2.0
+
+parameters:
+  cron:
+    type: boolean
+    default: false
 
 workflows:
+  automated-wf:
+    when: << pipeline.parameters.cron >>
+    jobs:
+      - check-feed:
+          context:
+            - cimg-publishing
   main-wf:
     jobs:
       - cimg/build-and-deploy:
@@ -24,3 +36,46 @@ workflows:
               only:
                 - main
           context: cimg-publishing
+jobs:
+  check-feed:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "f8:07:0f:f6:b5:eb:57:ae:be:4d:2f:2d:be:70:8f:ff"
+      - run:
+          name: SSH config to pull and push project
+          command: |
+            ssh-add -D
+            ssh-add ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff
+            ssh-keygen -f ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff -y > ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff.pub
+            echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch secops+cpe-image-bot@circleci.com" > ~/.ssh/allowed_signers
+      - run:
+          name: Run git config
+          command: |
+            cat \<<'EOF' >> ~/githelper.sh
+              #!/usr/bin/env bash
+              echo username=$GIT_USERNAME
+              echo password=$IMAGE_BOT_TOKEN
+            EOF
+
+            git config --global user.email "secops+cpe-image-bot@circleci.com"
+            git config --global user.name "cpe-image-bot"
+            git config --global user.signingkey "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch"
+            git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+            git config --global url."https://github.com".insteadOf ssh://git@github.com
+            git config --global url."https://github.com/".insteadOf git@github.com:
+            git config --global credential.helper "/bin/bash ~/githelper.sh"
+            git config --global gpg.format ssh
+            git config --global commit.gpgsign true
+            git submodule sync
+      - gh/setup:
+          token: IMAGE_BOT_TOKEN
+      - run:
+          name: Run version update script
+          command: |
+            sudo chmod +x deployFeed.sh
+            git submodule update --init --recursive
+            ./deployFeed.sh


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
adds the check-feed job to automate updates to cimg-deploy

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
a trigger will need to be set up to run the check-feed pipeline

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [N/A] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
