### PR TITLE
refactor: add cimg-build-and-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,9 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.3
+  cimg: circleci/cimg@0.3.4
+  aws-cli: circleci/aws-cli@4.1.0
+  slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
 parameters:
@@ -17,25 +19,37 @@ workflows:
           context:
             - cimg-publishing
   main-wf:
+    when:
+      not: << pipeline.parameters.cron >>
     jobs:
-      - cimg/build-and-deploy:
-          name: "Staging"
+      - cimg-build:
+          name: "Build and Stage"
           docker-namespace: ccitest
           docker-repository: deploy
-          publish-branch: test
           filters:
             branches:
               ignore:
                 - main
           context: cimg-publishing
-      - cimg/build-and-deploy:
+          post-steps:
+            - slack/notify:
+                branch_pattern: release-v.+
+                event: pass
+                mentions: "@jalexchen"
+                template: basic_success_1
+      - cimg-deploy:
           name: "Deploy"
-          docker-repository: deploy
           filters:
             branches:
               only:
                 - main
           context: cimg-publishing
+          post-steps:
+            - slack/notify:
+                branch_pattern: main
+                event: fail
+                mentions: "@images"
+                template: basic_fail_1
 jobs:
   check-feed:
     docker:
@@ -79,3 +93,74 @@ jobs:
             sudo chmod +x deployFeed.sh
             git submodule update --init --recursive
             ./deployFeed.sh
+
+  cimg-build:
+    docker:
+      - image: cimg/base:current
+    parameters:
+      docker-namespace:
+        type: string
+      docker-repository:
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Continue if Dockerfiles changed
+          command: |
+            CHANGE="false"
+            source GEN-CHECK
+            for version in "${GEN_CHECK[@]}"; do
+              directory="$(echo "$version" | cut -d '.' -f1).$(echo "$version" | cut -d '.' -f2)"
+              defaultBranch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+              git diff --quiet "$defaultBranch" -- "$directory" || CHANGE="true"
+            done
+            if [[ $CHANGE != "true" ]]; then
+              circleci step halt
+            fi
+      - cimg/build-images:
+          docker-namespace: <<parameters.docker-namespace>>
+          docker-repository: <<parameters.docker-repository>>
+
+  cimg-deploy:
+    docker:
+      - image: cimg/aws:2023.09.1
+    steps:
+      - checkout
+      - run:
+          name: Halt if not release
+          command: |
+            if ! git log -1 --pretty=%s | grep "\[release\]"; then
+              circleci step halt
+            fi
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: arn:aws:iam::483285841698:role/cpe-images-bucket-write
+          role_session_name: "write-to-s3"
+          profile_name: "s3write"
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: arn:aws:iam::483285841698:role/cpe-images-bucket-read
+          role_session_name: "read-from-s3"
+          profile_name: "s3read"
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: arn:aws:iam::483285841698:role/cpe-kms-sign
+          role_session_name: "sign-docker-images"
+      - run:
+          name: Install Cosign
+          command: |
+            url="https://github.com/sigstore/cosign/releases/latest/download/cosign-linux"
+            [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64"
+
+            if ! cosign version &> /dev/null; then
+              curl -O -L "$url-$ARCH" >cosign && \
+              sudo chmod 755 cosign
+              sudo cp cosign /usr/local/bin/
+            fi
+      - run:
+          name: Sign, Verify, Deploy
+          command: |
+            echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
+            git submodule update --init --recursive
+            ./shared/build-and-deploy.sh run


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
adds updated flow for building deploy images

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
checks for changes in dockerfiles for any given release month, then builds if needed. currently based on a quarter system, but will need to be changed to monthly

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [N/A] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
