### PR TITLE
[PROV-444] feat: add monthly triggers for deploy images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.6.0
+  cimg: circleci/cimg@0.6.1
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
@@ -36,6 +36,20 @@ workflows:
                 event: fail
                 mentions: "@images"
                 template: basic_fail_1
+      - trigger-images:
+          matrix:
+            parameters:
+              deploy-images:
+                - cimg-aws
+                - cimg-azure
+                - cimg-gcp
+          context: cimg-publishing
+          requires:
+            - cimg/build-and-deploy
+          filters:
+            branches:
+              only:
+                - main
 
 jobs:
   check-feed:
@@ -80,3 +94,26 @@ jobs:
             sudo chmod +x deployFeed.sh
             git submodule update --init --recursive
             ./deployFeed.sh
+
+  trigger-images:
+    parameters:
+      deploy-images:
+        type: string
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run:
+          name: "Check if release build"
+          command: |
+            if ! git log -1 --pretty=%s | grep "\[release\]"; then
+              echo "Not a release commit"
+              circleci step halt
+            fi
+      - run:
+          name: "Trigger utility image builds"
+          command: |
+            curl --request POST \
+            --url https://circleci.com/api/v2/project/gh/CircleCI-Public/<<parameters.deploy-images>>/pipeline \
+            --header "Circle-Token: $IMAGE_BOT_TOKEN" \
+            --header "content-type: application/json" \
+            --data '{"parameters":{"trigger": true}, "branch": "main" }}'

--- a/deployFeed.sh
+++ b/deployFeed.sh
@@ -24,7 +24,7 @@ function getHelm() {
 function deployFeed() {
   replaceDatedTags "$templateFile" ""
   getHelm "$HELM_URL" "^v[0-9]+(.[0-9]+)*$"
-  ./shared/release "$VERSION"
+  ./shared/release "$VERSION.1"
 }
 
 deployFeed "$templateFile"

--- a/deployFeed.sh
+++ b/deployFeed.sh
@@ -8,8 +8,8 @@ else
 fi
 
 templateFile="Dockerfile.template"
-interval="monthly"
 HELM_URL="https://api.github.com/repos/helm/helm/releases"
+VERSION=$( date +%Y.%m )
 
 function getHelm() {
   local url=$1
@@ -22,9 +22,9 @@ function getHelm() {
 }
 
 function deployFeed() {
-  replaceDatedTags "$templateFile" "$interval"
+  replaceDatedTags "$templateFile" ""
   getHelm "$HELM_URL" "^v[0-9]+(.[0-9]+)*$"
-  [[ -n $STRING_TO_REPLACE || -n $RELEASEMONTHLY ]] && ./shared/release "$RELEASEMONTHLY" || exit 0
+  ./shared/release "$VERSION"
 }
 
 deployFeed "$templateFile"


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
- adds a job to trigger building deploy-suite images every month
- a automated trigger will need to be added to create the deploy image itself any time after cimg/base

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
- part of an effort to automate our image builds. since this image and the other deploy-suite of images, which depend on `cimg/deploy` are updated monthly, it makes sense to trigger those builds from this repository once the image has been created

# Checklist

Please check through the following before opening your PR. Thank you!

- [] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
