### PR TITLE
fix: missing .sh

### DIFF
--- a/deployFeed.sh
+++ b/deployFeed.sh
@@ -24,7 +24,7 @@ function getHelm() {
 function deployFeed() {
   replaceDatedTags "$templateFile" ""
   getHelm "$HELM_URL" "^v[0-9]+(.[0-9]+)*$"
-  ./shared/release "$VERSION.1"
+  ./shared/release.sh "$VERSION.1"
 }
 
 deployFeed "$templateFile"


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
missing .sh to call release script