### PR TITLE
chore: update salt to the latest 22.04 release

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,8 +26,8 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
 
 	# Setup Salt
 	[[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
-	sudo curl -fsSL -o /usr/share/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/py3/ubuntu/20.04/${ARCH}/latest/salt-archive-keyring.gpg && \
-	echo "deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=${ARCH}] https://repo.saltproject.io/py3/ubuntu/20.04/${ARCH}/latest focal main" | sudo tee /etc/apt/sources.list.d/salt.list && \
+	sudo curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/22.04/${ARCH}/SALT-PROJECT-GPG-PUBKEY-2023.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=${ARCH}] https://repo.saltproject.io/salt/py3/ubuntu/22.04/${ARCH}/latest jammy main" | sudo tee /etc/apt/sources.list.d/salt.list \
 
 	# Setup Kubectl
 	# You must use a kubectl version that is within one minor version difference of your cluster. For example, a v1.23 client can communicate with v1.22, v1.23, and v1.24 control planes.


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Update to the latest Salt project release for Ubuntu 22.04 Jammy.

# Reasons
Updates the base dependent libraries to remove vulnerabilities.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
