### PR TITLE
Without a checkout, the git command fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
     docker:
       - image: cimg/base:current
     steps:
+      - checkout
       - run:
           name: "Check if release build"
           command: |


### PR DESCRIPTION
# Description
Give the downstream trigger PRs a better chance of being created.
