### PR TITLE
Update cimg-base to 2026.03-22.04

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@
 # specific reason to use a different one. This means January, April, July, or
 # October.
 
-FROM cimg/%%PARENT%%:2026.02-22.04
+FROM cimg/%%PARENT%%:2026.03-22.04
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 


### PR DESCRIPTION
Updates the base image tag from `2026.02-22.04` to `2026.03-22.04`.